### PR TITLE
added usingInterrup(255)

### DIFF
--- a/SST25VF.cpp
+++ b/SST25VF.cpp
@@ -37,7 +37,7 @@ void SST25VF::begin(int chipSelect,int writeProtect,int hold){
   
   sstSPISettings = SPISettings(SST25VF_SPI_CLOCK, SST25VF_SPI_BIT_ORDER, SST25VF_SPI_MODE);
   SPI.begin();
-	
+	SPI.usingInterrupt(255);
   init(); 
 	readID();
 }


### PR DESCRIPTION
added usingInterrupt(255) as recommended by Paul Stoffregen in SPI.h source code (https://github.com/PaulStoffregen/SPI/blob/master/SPI.h)

this fixed an unexpected hung-up while streaming data using an ISR and attempting to read RFID tags on MFRC522